### PR TITLE
Fix Parakeet engine: retry init, full v3 language list, gate v2

### DIFF
--- a/Overwhisper/Transcription/ParakeetEngine.swift
+++ b/Overwhisper/Transcription/ParakeetEngine.swift
@@ -12,6 +12,9 @@ actor ParakeetEngine: TranscriptionEngine {
         self.appState = appState
     }
 
+    private static let maxRetries = 3
+    private static let retryDelaySeconds: UInt64 = 5
+
     func initialize() async throws {
         guard !isInitializing else {
             AppLogger.transcription.debug("Parakeet initialization already in progress, skipping")
@@ -39,32 +42,41 @@ actor ParakeetEngine: TranscriptionEngine {
             appState.currentlyDownloadingModel = modelType.rawValue
         }
 
-        do {
-            let models = try await AsrModels.downloadAndLoad(version: modelVersion)
-            let manager = AsrManager(config: .default)
-            try await manager.loadModels(models)
-            asrManager = manager
-            isInitialized = true
+        for attempt in 1...Self.maxRetries {
+            do {
+                let models = try await AsrModels.downloadAndLoad(version: modelVersion)
+                let manager = AsrManager(config: .default)
+                try await manager.loadModels(models)
+                asrManager = manager
+                isInitialized = true
 
-            await MainActor.run {
-                appState.isDownloadingModel = false
-                appState.currentlyDownloadingModel = nil
-                appState.parakeetDownloadedModels.insert(modelType.rawValue)
+                await MainActor.run {
+                    appState.isDownloadingModel = false
+                    appState.currentlyDownloadingModel = nil
+                    appState.parakeetDownloadedModels.insert(modelType.rawValue)
+                }
+
+                AppLogger.transcription.info("Parakeet initialized successfully")
+                return
+            } catch {
+                isInitialized = false
+                asrManager = nil
+
+                AppLogger.transcription.error("Failed to initialize Parakeet (attempt \(attempt)/\(Self.maxRetries)): \(error.localizedDescription)")
+
+                if attempt < Self.maxRetries {
+                    AppLogger.transcription.info("Retrying in \(Self.retryDelaySeconds) seconds...")
+                    try? await Task.sleep(nanoseconds: Self.retryDelaySeconds * 1_000_000_000)
+                } else {
+                    await MainActor.run {
+                        appState.isDownloadingModel = false
+                        appState.currentlyDownloadingModel = nil
+                        appState.lastError = "Failed to initialize Parakeet: \(error.localizedDescription)"
+                    }
+
+                    throw ParakeetError.initializationFailed(error.localizedDescription)
+                }
             }
-
-            AppLogger.transcription.info("Parakeet initialized successfully")
-        } catch {
-            isInitialized = false
-            asrManager = nil
-
-            await MainActor.run {
-                appState.isDownloadingModel = false
-                appState.currentlyDownloadingModel = nil
-                appState.lastError = "Failed to initialize Parakeet: \(error.localizedDescription)"
-            }
-
-            AppLogger.transcription.error("Failed to initialize Parakeet: \(error.localizedDescription)")
-            throw ParakeetError.initializationFailed(error.localizedDescription)
         }
     }
 

--- a/Overwhisper/UI/SettingsView.swift
+++ b/Overwhisper/UI/SettingsView.swift
@@ -199,24 +199,48 @@ struct TranscriptionSettingsView: View {
         ("ar", "Arabic")
     ]
 
-    private let parakeetLanguages = [
+    // Parakeet v3 transcribes 25 European languages (auto-detected). The
+    // language selection is passed as a script hint where applicable; codes
+    // outside FluidAudio's script-filter enum fall back to auto-detection.
+    private let parakeetV3Languages = [
         ("auto", "Auto-detect"),
         ("bg", "Bulgarian"),
         ("hr", "Croatian"),
         ("cs", "Czech"),
+        ("da", "Danish"),
+        ("nl", "Dutch"),
         ("en", "English"),
+        ("et", "Estonian"),
+        ("fi", "Finnish"),
         ("fr", "French"),
         ("de", "German"),
+        ("el", "Greek"),
+        ("hu", "Hungarian"),
         ("it", "Italian"),
+        ("lv", "Latvian"),
+        ("lt", "Lithuanian"),
+        ("mt", "Maltese"),
         ("pl", "Polish"),
         ("pt", "Portuguese"),
         ("ro", "Romanian"),
-        ("ru", "Russian"),
         ("sk", "Slovak"),
         ("sl", "Slovenian"),
         ("es", "Spanish"),
+        ("sv", "Swedish"),
+        ("ru", "Russian"),
         ("uk", "Ukrainian")
     ]
+
+    // Parakeet v2 is English-only.
+    private let parakeetV2Languages = [
+        ("en", "English")
+    ]
+
+    // The language options offered for the active engine/model selection.
+    private var availableLanguages: [(String, String)] {
+        guard isUsingParakeet else { return whisperLanguages }
+        return appState.parakeetModel == .v2English ? parakeetV2Languages : parakeetV3Languages
+    }
 
     private var engineDescription: String {
         switch appState.transcriptionEngine {
@@ -329,16 +353,21 @@ struct TranscriptionSettingsView: View {
             // 3. Language
             Section {
                 Picker("Language", selection: $appState.language) {
-                    ForEach(isUsingParakeet ? parakeetLanguages : whisperLanguages, id: \.0) { code, name in
+                    ForEach(availableLanguages, id: \.0) { code, name in
                         Text(name).tag(code)
                     }
                 }
+                .disabled(isUsingParakeet && appState.parakeetModel == .v2English)
 
                 Toggle("Translate to English", isOn: $appState.translateToEnglish)
             } header: {
                 Text("Language")
             } footer: {
-                if appState.translateToEnglish {
+                if isUsingParakeet && appState.parakeetModel == .v2English {
+                    Text("Parakeet v2 is English-only. Switch to v3 for other languages.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else if appState.translateToEnglish {
                     Text("Audio will be translated to English. Requires a multilingual model.")
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -346,6 +375,12 @@ struct TranscriptionSettingsView: View {
                     Text("Select the language you'll be speaking, or Auto-detect to let the model identify it.")
                         .font(.caption)
                         .foregroundColor(.secondary)
+                }
+            }
+            .onChange(of: appState.parakeetModel) { _, newModel in
+                // v2 only speaks English; clamp any stale multilingual selection.
+                if isUsingParakeet, newModel == .v2English {
+                    appState.language = "en"
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
 
 <p align="center">
   Press a hotkey, speak, and Overwhisper inserts the text wherever your cursor is.
-  It lives in the menu bar, runs local speech-to-text on your Mac by default, and
-  does not ask you to rent access to hardware you already bought.
+  It lives in the menu bar, runs local WhisperKit or Parakeet speech-to-text on
+  your Mac by default, and does not ask you to rent access to hardware you
+  already bought.
 </p>
 
 <p align="center">
@@ -35,7 +36,8 @@ The goal is not "voice notes". The goal is to make speaking into any Mac text
 field feel as direct as typing:
 
 - Hold a hotkey while writing in Slack, Notes, Linear, your browser, or your IDE.
-- Use Apple Silicon-optimized local models for private, low-latency transcription.
+- Choose WhisperKit or Parakeet local models for private, low-latency
+  transcription on Apple Silicon.
 - Keep a polished menu bar workflow with onboarding, model management, waveform
   feedback, recent transcriptions, retry, and sensible failure handling.
 - Choose cloud transcription only when you explicitly want it.
@@ -66,8 +68,8 @@ Release builds are arm64-only.
 ### Local-first transcription
 
 - **WhisperKit** local transcription, optimized for Apple Silicon.
-- **Parakeet** local transcription via FluidAudio, with English and multilingual
-  model options.
+- **Parakeet** local transcription via FluidAudio, including Parakeet v2 English
+  and Parakeet v3 multilingual model options.
 - **OpenAI Whisper API** as an optional cloud engine when you prefer hosted
   transcription.
 - Download, select, and delete local models from the settings UI.

--- a/README.md
+++ b/README.md
@@ -1,129 +1,211 @@
 # Overwhisper
 
-A native macOS menu bar app for voice transcription. Press a global hotkey, speak, and the text is typed at your cursor. Runs locally on-device by default (WhisperKit or Parakeet), with optional OpenAI cloud transcription.
+<p align="center">
+  <img src="docs/icon.png" alt="Overwhisper icon" width="96" height="96">
+</p>
+
+<p align="center">
+  <strong>Fast, private dictation for macOS. Free and open source.</strong>
+</p>
+
+<p align="center">
+  Press a hotkey, speak, and Overwhisper inserts the text wherever your cursor is.
+  It lives in the menu bar, runs local speech-to-text on your Mac by default, and
+  does not ask you to rent access to hardware you already bought.
+</p>
+
+<p align="center">
+  <a href="https://github.com/OverseedAI/overwhisper/releases/latest">Download</a>
+  ·
+  <a href="#features">Features</a>
+  ·
+  <a href="#building-from-source">Build from source</a>
+  ·
+  <a href="#contributing">Contribute</a>
+</p>
+
+## Why Overwhisper?
+
+There are plenty of dictation apps that run transcription on the user's own
+machine and still charge a subscription for the privilege. Overwhisper takes the
+more obvious deal: your Mac does the work, so the core app is free, local-first,
+and open source.
+
+The goal is not "voice notes". The goal is to make speaking into any Mac text
+field feel as direct as typing:
+
+- Hold a hotkey while writing in Slack, Notes, Linear, your browser, or your IDE.
+- Use Apple Silicon-optimized local models for private, low-latency transcription.
+- Keep a polished menu bar workflow with onboarding, model management, waveform
+  feedback, recent transcriptions, retry, and sensible failure handling.
+- Choose cloud transcription only when you explicitly want it.
 
 ## Download & Install
 
-1. Grab the latest DMG from the [releases page](https://github.com/OverseedAI/overwhisper/releases/latest) — `Overwhisper-X.Y.Z.dmg`.
+1. Download the latest signed DMG from
+   [GitHub Releases](https://github.com/OverseedAI/overwhisper/releases/latest).
 2. Open the DMG and drag **Overwhisper.app** into `/Applications`.
-3. Launch it from Applications (or Spotlight). The first launch may show a Gatekeeper prompt — the app is signed and notarized, so just click **Open**.
-4. Grant permissions when prompted:
-   - **Microphone** — required for recording.
-   - **Accessibility** — required for global hotkeys and pasting text at the cursor.
-5. The icon appears in the menu bar (no dock icon). Click it to open Settings and pick a hotkey + model.
+3. Launch Overwhisper from Applications or Spotlight.
+4. Grant the requested permissions:
+   - **Microphone** records your speech.
+   - **Accessibility** lets Overwhisper paste text into the app you are using.
+5. Pick a model in Settings and start dictating.
 
-Updates are delivered automatically via Sparkle — you'll get a prompt when a new version is available.
+Overwhisper is a menu bar app. It does not show a Dock icon.
 
 ### Requirements
 
-- macOS 14.0 (Sonoma) or later
-- Apple Silicon (M1 or newer) — release builds are arm64-only
-- Microphone + Accessibility permissions
+- macOS 14 Sonoma or later
+- Apple Silicon Mac, M1 or newer
+- Microphone and Accessibility permissions
+
+Release builds are arm64-only.
 
 ## Features
 
-- **Global hotkey** — configurable system-wide shortcut, push-to-talk or toggle.
-- **Local transcription** — choose between [WhisperKit](https://github.com/argmaxinc/WhisperKit) or [Parakeet](https://github.com/FluidInference/FluidAudio) (via FluidAudio), both running on-device on Apple Silicon.
-- **Cloud option** — OpenAI Whisper API as primary engine or fallback.
-- **Recording overlay** — floating indicator with live waveform; configurable position.
-- **Cursor-aware paste** — transcribed text is inserted wherever you're typing.
-- **Auto-updates** — Sparkle handles version checks and installs.
+### Local-first transcription
 
-## Usage
+- **WhisperKit** local transcription, optimized for Apple Silicon.
+- **Parakeet** local transcription via FluidAudio, with English and multilingual
+  model options.
+- **OpenAI Whisper API** as an optional cloud engine when you prefer hosted
+  transcription.
+- Download, select, and delete local models from the settings UI.
 
-1. Focus any text field (Notes, browser, Slack, your IDE, etc.).
-2. Press the configured hotkey.
-3. Speak.
-4. Release the hotkey (push-to-talk) or press it again (toggle).
-5. The transcription is pasted at the cursor.
+### Built for real daily use
 
-## Settings
+- **Two hotkey styles:** `Option+Space` toggles recording, and
+  `Option+Shift+Space` is push-to-talk by default. Both are configurable.
+- **Tap-or-hold behavior:** tap the toggle hotkey to start/stop, or hold it like
+  push-to-talk and release to transcribe.
+- **Cursor-aware insertion:** text is pasted into the active app, not trapped in
+  a separate transcript window.
+- **Floating overlay:** configurable position with live waveform and transcribing
+  state.
+- **Menu bar controls:** start/stop recording, copy recent transcriptions, retry
+  the last failed transcription, open settings, and check for updates.
+- **Input device selection:** use the system default microphone or choose a
+  specific input device.
 
-- **General** — hotkey, recording mode, overlay position, start at login.
-- **Transcription** — engine (WhisperKit / Parakeet / OpenAI), model size, language, cloud fallback.
-- **Output** — completion sound, error notifications.
-- **Debug** — audio playback, logs.
+### Quality-of-life tools
 
-## Building from Source
+- **Custom vocabulary** for names, acronyms, and project-specific terms.
+- **Text replacements** for fixing predictable mishearings, like
+  `Cloud Code -> Claude Code`.
+- **Language selection** with auto-detect, common Whisper languages, and
+  Parakeet language hints.
+- **Translate to English** when using a model/API mode that supports translation.
+- **Silent recording detection** so accidental empty captures can be skipped.
+- **Optional recording limit** for long-running hotkey mistakes.
+- **Optional system-audio mute** while recording with built-in speakers.
+- **Recent transcription history** and local debug sessions for playback, retry,
+  and troubleshooting.
+- **Sparkle updates** for signed release builds.
 
-Requires Xcode 15+ and the Swift toolchain.
+## How It Works
 
-```bash
-just build          # debug build
-just run            # run debug build
-just build-release  # release build
-just bundle         # produce Overwhisper.app
-```
+1. Focus any text field.
+2. Press your Overwhisper hotkey.
+3. Speak naturally.
+4. Release the push-to-talk hotkey, or press the toggle hotkey again.
+5. Overwhisper transcribes the audio and inserts the result at the cursor.
 
-Or directly with SwiftPM:
+If Accessibility permission is missing, Overwhisper copies the text to the
+clipboard and tells you to paste manually.
+
+## Privacy
+
+Overwhisper is local-first.
+
+- Audio stays on your Mac when using WhisperKit or Parakeet.
+- Audio is sent to OpenAI only when the OpenAI engine is selected, or when cloud
+  fallback has been enabled in local settings and a local transcription fails.
+- OpenAI API keys are stored in the macOS Keychain.
+- Recent debug sessions are stored locally under Application Support so you can
+  inspect audio, retry failures, and troubleshoot issues. The app keeps a capped
+  set of recent sessions and includes a Clear All control in Settings.
+- Overwhisper does not include analytics or tracking.
+
+## Building From Source
+
+Requires Xcode 15+ and Swift 5.9+.
 
 ```bash
 swift build
 swift run Overwhisper
 ```
 
-For Xcode: `open Package.swift` (or `open Overwhisper.xcodeproj`).
+Or use the Justfile:
 
-## Architecture
-
-Menu bar app with no dock presence. `AppDelegate` coordinates the components:
-
+```bash
+just build          # debug build
+just run            # run debug build
+just build-release  # release build
+just bundle         # create Overwhisper.app
 ```
+
+For Xcode:
+
+```bash
+open Package.swift
+```
+
+When running inside Codex or another Seatbelt sandbox, SwiftPM may fail while
+trying to create its own nested sandbox or write shared caches. Use:
+
+```bash
+swift build --disable-sandbox --cache-path .swiftpm-cache
+```
+
+## Project Structure
+
+```text
 Overwhisper/
-├── App/
-│   ├── OverwhisperApp.swift     # SwiftUI entry point
-│   ├── AppDelegate.swift        # Menu bar + component coordination
-│   ├── AppState.swift           # Observable state, @AppStorage settings
-│   └── CrashReporter.swift
-├── Audio/
-│   └── AudioRecorder.swift      # AVAudioEngine, 16kHz mono WAV
-├── Hotkey/
-│   └── HotkeyManager.swift      # Global hotkey via HotKey lib
-├── Transcription/
-│   ├── TranscriptionEngine.swift  # Protocol
-│   ├── WhisperKitEngine.swift     # Local (WhisperKit)
-│   ├── ParakeetEngine.swift       # Local (FluidAudio / Parakeet)
-│   ├── OpenAIEngine.swift         # Cloud (OpenAI API)
-│   └── ModelManager.swift         # Model download / cache management
-├── Output/
-│   └── TextInserter.swift       # Clipboard + synthetic Cmd+V
-├── UI/
-│   ├── OverlayWindow.swift      # Floating NSPanel
-│   ├── OverlayView.swift        # Recording animation
-│   ├── SettingsView.swift       # Tabbed settings
-│   ├── OnboardingView.swift
-│   ├── MenuBarIcon.swift
-│   └── DebugAudioPlayer.swift
-├── Logging/
-└── Resources/
+├── App/              # App delegate, app state, onboarding, crash handling
+├── Audio/            # AVAudioEngine recording and device handling
+├── Hotkey/           # Global keyboard shortcuts via HotKey
+├── Logging/          # App logs and local debug session storage
+├── Output/           # Clipboard + synthetic Cmd+V text insertion
+├── Resources/        # App icon and bundled assets
+├── Transcription/    # WhisperKit, Parakeet, and OpenAI engines
+└── UI/               # Settings, overlay, menu bar icon, debug playback
 ```
 
-### Recording flow
+The core recording flow is:
 
-1. `HotkeyManager` detects the global hotkey and notifies `AppDelegate`.
-2. `AudioRecorder` captures mic input (AVAudioEngine, 16 kHz mono WAV).
-3. `OverlayWindow` displays the recording indicator with a live waveform.
-4. On stop, the WAV is handed to the selected `TranscriptionEngine`.
-5. `TextInserter` pastes the result via clipboard + synthetic Cmd+V.
+1. `HotkeyManager` receives the global hotkey event.
+2. `AudioRecorder` records a 16 kHz mono WAV through `AVAudioEngine`.
+3. `OverlayWindow` shows recording and transcribing state.
+4. The selected `TranscriptionEngine` produces text.
+5. `TextInserter` pastes the final text into the active app.
 
 ## Dependencies
 
-- [WhisperKit](https://github.com/argmaxinc/WhisperKit) — local Whisper transcription
-- [FluidAudio](https://github.com/FluidInference/FluidAudio) — Parakeet engine
-- [HotKey](https://github.com/soffes/HotKey) — global hotkey handling
-- [Sparkle](https://github.com/sparkle-project/Sparkle) — auto-updates
+- [WhisperKit](https://github.com/argmaxinc/WhisperKit) for local Whisper models.
+- [FluidAudio](https://github.com/FluidInference/FluidAudio) for Parakeet ASR.
+- [HotKey](https://github.com/soffes/HotKey) for global shortcuts.
+- [Sparkle](https://github.com/sparkle-project/Sparkle) for app updates.
 
-## Privacy
+## Contributing
 
-- Audio stays on-device when using WhisperKit or Parakeet.
-- Recordings are written to a temp file and deleted right after transcription.
-- The OpenAI API key (if you use one) is stored in the macOS Keychain.
-- Nothing is collected or transmitted except audio sent to OpenAI when that engine is selected.
+Contributions are welcome. Useful areas include:
+
+- Dictation UX polish and reliability.
+- Model download and setup experience.
+- Better language/model documentation.
+- Accessibility and permission-flow improvements.
+- Bug reports with macOS version, Mac model, selected engine/model, and the
+  relevant error from the menu bar or History tab.
+
+Please keep changes focused, use the existing SwiftUI/SwiftPM style, and prefer
+small pull requests that are easy to review.
 
 ## Support
 
-Overwhisper is free and open source. If it saves you time, you can support development at [buymeacoffee.com/halshin](https://buymeacoffee.com/halshin).
+Overwhisper is free and open source. If it saves you time and you want to support
+development, you can do that at
+[buymeacoffee.com/halshin](https://buymeacoffee.com/halshin).
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
Tackles three non-blocking issues surfaced in the PR #10 Parakeet review.

## Changes
- **Closes #13** — `ParakeetEngine.initialize()` now retries `downloadAndLoad`/`loadModels` 3× with 5s backoff, mirroring `WhisperKitEngine`. Previously single-shot, so a transient network blip on the first download forced a manual retry.
- **Closes #11** — Parakeet v3 language picker now lists all **25** supported European languages (was 15). Verified against FluidAudio's source: the `Language` enum is a Latin/Cyrillic *script hint*, not a transcription gate — codes outside it fall back to auto-detection harmlessly, so listing the full 25 matches the model's actual capability and the engine description.
- **Closes #12** — When Parakeet v2 (English-only) is selected, the language picker is disabled, shows English only, clamps any stale multilingual selection to `en`, and surfaces a footer note.

## Validation
- `swift build` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)